### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/auth0/packageify"
+  },
   "homepage": "https://github.com/jfromaniello/packageify",
   "keywords": [
     "browserify",


### PR DESCRIPTION
This will prevent this warning `npm WARN package.json packageify@0.2.1 No repository field.` from showing up when installing.