### PR TITLE
Non greedy regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function getPackageJson (inDir) {
 
 module.exports = function (file, opts) {
   return through(function write(data) {
-    data = data.toString().replace(/require\((\'|\")package\.(.*)(\'|\")\)/ig, function (str, p1, p2) {
+    data = data.toString().replace(/require\((\'|\")package\.(.*?)(\'|\")\)/ig, function (str, p1, p2) {
       var r = JSON.stringify(require(getPackageJson(file))[p2]);
       return r;
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,20 +1,35 @@
 var packageify = require('..');
 var path = require('path');
 var test = require('tape');
+var TEST_FILE_PATH = __filename;
 
 test('Replaces "package.x" requires with data from package.json', function(t) {
   var buffer = '';
-  var testFilePath = __filename;
-
-  packageify(testFilePath)
+  packageify(TEST_FILE_PATH)
     .on('data', function(d) { buffer += d })
     .on('end', function() {
-      t.ok(buffer.indexOf('Example Person') > -1);
       t.ok(buffer.indexOf('1.0.3') > -1);
+      t.ok(buffer.indexOf('Example Person') > -1);
       t.end()
     })
     .end([
         "var version = require('package.version');",
+        "var author = require('package.author');"
+    ].join('\n'))
+});
+
+test('Allows for chaining off of a require by non greedily matching "package.x" requires', function(t) {
+  var buffer = '';
+
+  packageify(TEST_FILE_PATH)
+    .on('data', function(d) { buffer += d })
+    .on('end', function() {
+      t.ok(buffer.indexOf('"1.0.3".split(') > -1);
+      t.ok(buffer.indexOf('Example Person') > -1);
+      t.end()
+    })
+    .end([
+        "var majorVersion = require('package.version').split('.')[0];",
         "var author = require('package.author');"
     ].join('\n'))
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -9,8 +9,8 @@ test('Replaces "package.x" requires with data from package.json', function(t) {
   packageify(testFilePath)
     .on('data', function(d) { buffer += d })
     .on('end', function() {
-      t.ok(buffer.indexOf('1.0.3') > -1);
       t.ok(buffer.indexOf('Example Person') > -1);
+      t.ok(buffer.indexOf('1.0.3') > -1);
       t.end()
     })
     .end([


### PR DESCRIPTION
This fixes an issue where `require` statements that did something with the required package, e.g. 

```javascript
var majorVersion = require('package.version').split('.')[0];
```

Would be turned into: 

```javascript
var majorVersion = undefined.split('.')[0];
```

Because the regex was greedily matching from `require(` to `.split('.')`

It depends on #4 being merged.