### PR TITLE
Correct homepage in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "https://github.com/auth0/packageify"
   },
-  "homepage": "https://github.com/jfromaniello/packageify",
+  "homepage": "https://github.com/auth0/packageify",
   "keywords": [
     "browserify",
     "browserify-transform",


### PR DESCRIPTION
The current homepage results in a 404. This switches the homepage to be the same page as the repository information.